### PR TITLE
Pin backend dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,7 @@
-fastapi
-uvicorn
-pandas
-python-dotenv
-
-
-sqlalchemy
-psycopg2-binary
-python-dotenv
+fastapi==0.116.1
+uvicorn==0.35.0
+pandas==2.3.1
+python-dotenv==1.1.1
+sqlalchemy==2.0.41
+psycopg2-binary==2.9.10
+python-dateutil==2.9.0


### PR DESCRIPTION
## Summary
- pin backend dependencies to exact versions
- add python-dateutil and remove duplicate python-dotenv entry

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874c80b3204832d964aa436fb82d01a