### PR TITLE
Clarify env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ This project provides a prototype analytics dashboard with a FastAPI backend and
    ```
 ### Environment Variables
 
-1. Copy the sample environment file:
+1. Copy the sample environment file. From inside `backend` use:
 
    ```bash
-   cp .env.sample .env
+   cp ../.env.sample .env
    ```
+
+   (Or run `cp .env.sample .env` from the project root.)
+
+   The backend uses `python-dotenv` to automatically load variables from this
+   `.env` file when `backend/DB/connector.py` imports `load_dotenv()`.
 
 2. Edit `.env` and provide values for:
 


### PR DESCRIPTION
## Summary
- clarify how to copy the sample environment file
- mention that python-dotenv automatically loads the file

## Testing
- `pytest -q` *(fails: No module named 'API.API_Dashboard')*

------
https://chatgpt.com/codex/tasks/task_e_6874d3165520832db5c5c74b077d9093